### PR TITLE
feat: config loader transformer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ plugins:
             - https://docs.python.org/3/objects.inv
           options:
             docstring_style: google
+            show_docstring_warns: true
             show_submodules: true
             enable_inventory: true
             separate_signature: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -399,22 +399,18 @@ semver = ">=2.13,<3.0"
 
 [[package]]
 name = "griffe"
-version = "0.28.1.dev1+g5ffdd78"
+version = "0.28.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
-files = []
-develop = false
+files = [
+    {file = "griffe-0.28.1-py3-none-any.whl", hash = "sha256:a39fc547c964fcf2c0569834efce4978b7c528ef5a67eb9bdf6d0388ebced5a9"},
+    {file = "griffe-0.28.1.tar.gz", hash = "sha256:2990f97f1e94dcfc444756c3f1350ef78465f6238594a292b0c426ab62c00479"},
+]
 
 [package.dependencies]
 colorama = ">=0.4"
-
-[package.source]
-type = "git"
-url = "https://github.com/mkdocstrings/griffe.git"
-reference = "5ffdd7861a828794edf569bcfaeb8e26601df88c"
-resolved_reference = "5ffdd7861a828794edf569bcfaeb8e26601df88c"
 
 [[package]]
 name = "idna"
@@ -749,14 +745,14 @@ mkdocs = ">=1.0.3"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.1.13"
+version = "9.1.14"
 description = "Documentation that simply works"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mkdocs_material-9.1.13-py3-none-any.whl", hash = "sha256:5705cf8cb6c47c747606bd914bb6c01993ff141295cd259475559a1f09f07d5d"},
-    {file = "mkdocs_material-9.1.13.tar.gz", hash = "sha256:9102e7604d73e507021847601b0a8b4fe9035422788390183f464fa3b30dd508"},
+    {file = "mkdocs_material-9.1.14-py3-none-any.whl", hash = "sha256:b56a9f955ed32d38333715cbbf68ce38f683bf38610c65094fa4ef2db9f08bcd"},
+    {file = "mkdocs_material-9.1.14.tar.gz", hash = "sha256:1ae74cc5464ef2f64574d4884512efed7f4db386fb9bc6af20fd427d7a702f49"},
 ]
 
 [package.dependencies]
@@ -1250,14 +1246,14 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.30.0"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "requests-2.30.0-py3-none-any.whl", hash = "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294"},
-    {file = "requests-2.30.0.tar.gz", hash = "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
@@ -1403,19 +1399,19 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "67.7.2"
+version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.7.2-py3-none-any.whl", hash = "sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b"},
-    {file = "setuptools-67.7.2.tar.gz", hash = "sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990"},
+    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -1490,14 +1486,14 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.9"
+version = "6.0.12.10"
 description = "Typing stubs for PyYAML"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-PyYAML-6.0.12.9.tar.gz", hash = "sha256:c51b1bd6d99ddf0aa2884a7a328810ebf70a4262c292195d3f4f9a0005f9eeb6"},
-    {file = "types_PyYAML-6.0.12.9-py3-none-any.whl", hash = "sha256:5aed5aa66bd2d2e158f75dda22b059570ede988559f030cf294871d3b647e3e8"},
+    {file = "types-PyYAML-6.0.12.10.tar.gz", hash = "sha256:ebab3d0700b946553724ae6ca636ea932c1b0868701d4af121630e78d695fc97"},
+    {file = "types_PyYAML-6.0.12.10-py3-none-any.whl", hash = "sha256:662fa444963eff9b68120d70cda1af5a5f2aa57900003c2006d7626450eaae5f"},
 ]
 
 [[package]]
@@ -1514,14 +1510,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.5.0"
+version = "4.6.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+    {file = "typing_extensions-4.6.0-py3-none-any.whl", hash = "sha256:6ad00b63f849b7dcc313b70b6b304ed67b2b2963b3098a33efe18056b1a9a223"},
+    {file = "typing_extensions-4.6.0.tar.gz", hash = "sha256:ff6b238610c747e44c268aa4bb23c8c735d665a63726df3f9431ce707f2aa768"},
 ]
 
 [[package]]
@@ -1707,4 +1703,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d9a70d25e51179e3279a052ced87a39bbac51fb7e02b1a3343b8f3c9efbdf645"
+content-hash = "ae9683a1c7995250420260c5e2b62f8454c7ceb4ba7309722172700560fd4b81"

--- a/poetry.lock
+++ b/poetry.lock
@@ -399,7 +399,7 @@ semver = ">=2.13,<3.0"
 
 [[package]]
 name = "griffe"
-version = "0.28.1.dev1+gf9418f1"
+version = "0.28.1.dev1+g5ffdd78"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
@@ -412,9 +412,9 @@ colorama = ">=0.4"
 
 [package.source]
 type = "git"
-url = "https://github.com/maxb2/griffe.git"
-reference = "master"
-resolved_reference = "f9418f17ca251555b4f5f4554cec9bb59dfaff08"
+url = "https://github.com/mkdocstrings/griffe.git"
+reference = "5ffdd7861a828794edf569bcfaeb8e26601df88c"
+resolved_reference = "5ffdd7861a828794edf569bcfaeb8e26601df88c"
 
 [[package]]
 name = "idna"
@@ -1707,4 +1707,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "df411be9e6595f8c9dd14eded7dc175d6b1fd695d8fdf8d0e7890b5f076f1925"
+content-hash = "d9a70d25e51179e3279a052ced87a39bbac51fb7e02b1a3343b8f3c9efbdf645"

--- a/poetry.lock
+++ b/poetry.lock
@@ -399,18 +399,22 @@ semver = ">=2.13,<3.0"
 
 [[package]]
 name = "griffe"
-version = "0.27.5"
+version = "0.28.1.dev1+gf9418f1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
-files = [
-    {file = "griffe-0.27.5-py3-none-any.whl", hash = "sha256:15b48fc3cebfc1c1a1a2f6e8177f6644a4a54517322e08e224fdf671454b34d7"},
-    {file = "griffe-0.27.5.tar.gz", hash = "sha256:96fbc7a264bdb32b4da227bed6a16f2509e028a12d7471dbb48c2785bb01817f"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 colorama = ">=0.4"
+
+[package.source]
+type = "git"
+url = "https://github.com/maxb2/griffe.git"
+reference = "master"
+resolved_reference = "f9418f17ca251555b4f5f4554cec9bb59dfaff08"
 
 [[package]]
 name = "idna"
@@ -1703,4 +1707,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "56eb6e479a795627978a1eb508e728f9614d9b412e87e06d264f71021fccf541"
+content-hash = "df411be9e6595f8c9dd14eded7dc175d6b1fd695d8fdf8d0e7890b5f076f1925"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ git-changelog = "^1.0.1"
 duty = "^0.11.0"
 pytest-cov = "^4.0.0"
 safety = "^2.3.5"
-griffe = "^0.27.5"
+griffe = { git = "https://github.com/maxb2/griffe.git", branch = "master" }
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.1.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ git-changelog = "^1.0.1"
 duty = "^0.11.0"
 pytest-cov = "^4.0.0"
 safety = "^2.3.5"
-griffe = { git = "https://github.com/mkdocstrings/griffe.git", rev = "5ffdd7861a828794edf569bcfaeb8e26601df88c" }
+griffe = "^0.28.1"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.1.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ git-changelog = "^1.0.1"
 duty = "^0.11.0"
 pytest-cov = "^4.0.0"
 safety = "^2.3.5"
-griffe = { git = "https://github.com/maxb2/griffe.git", branch = "master" }
+griffe = { git = "https://github.com/mkdocstrings/griffe.git", rev = "5ffdd7861a828794edf569bcfaeb8e26601df88c" }
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.1.9"

--- a/typer_config/__typing.py
+++ b/typer_config/__typing.py
@@ -27,6 +27,14 @@ ConfigDictAccessorPath: TypeAlias = Iterable[str]
 """Configuration dictionary accessor path."""
 
 # Function types
+TyperParameterValueTransformer: TypeAlias = Callable[
+    [TyperParameterValue], TyperParameterValue
+]
+"""Typer parameter value transforming function."""
+
+ConfigDictTransformer: TypeAlias = Callable[[ConfigDict], ConfigDict]
+"""ConfigDict transforming function."""
+
 ConfigLoader: TypeAlias = Callable[[TyperParameterValue], ConfigDict]
 """Configuration loader function."""
 


### PR DESCRIPTION
This creates a config loader transformer that lets you arbitrarily transform the input and output of a loader.
The main goal is to provide a general framework to replace `subpath_loader` and `default_value_loader`.

Closes #20 
Blocked by https://github.com/mkdocstrings/griffe/pull/161