### PR TITLE
refactor: modernize type hints and use Path.open()

### DIFF
--- a/src/typer_config/__optional_imports.py
+++ b/src/typer_config/__optional_imports.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from importlib.util import find_spec
 
 
-@lru_cache()
+@lru_cache
 def try_import(module_name: str):  # noqa: ANN202 (no type for modules)
     """Try to import a module by name.
 

--- a/src/typer_config/__typing.py
+++ b/src/typer_config/__typing.py
@@ -1,7 +1,8 @@
 """Data and Function types."""
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, TypeAlias, Union
+from typing import Any, TypeAlias
 
 from typer import CallbackParam, Context
 
@@ -12,11 +13,11 @@ TyperParameterName: TypeAlias = str
 TyperParameterValue: TypeAlias = Any
 """Typer CLI parameter value."""
 
-ConfigDict: TypeAlias = Dict[TyperParameterName, Any]
+ConfigDict: TypeAlias = dict[TyperParameterName, Any]
 """Configuration dictionary to be applied to the click context default map."""
 
 
-FilePath: TypeAlias = Union[Path, str]
+FilePath: TypeAlias = Path | str
 """File path"""
 
 # Function types

--- a/src/typer_config/callbacks.py
+++ b/src/typer_config/callbacks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from typer import BadParameter, CallbackParam, Context
 
 # NOTE: I'm not sure why, but these types must be imported at runtime
@@ -139,8 +137,8 @@ Returns:
 
 
 def argument_list_callback(
-    ctx: Context, param: CallbackParam, param_value: Optional[List[str]]
-) -> List[str]:
+    ctx: Context, param: CallbackParam, param_value: list[str] | None
+) -> list[str]:
     """Argument list callback.
 
     Note:

--- a/src/typer_config/decorators.py
+++ b/src/typer_config/decorators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 from typer import Option
 
@@ -101,10 +101,10 @@ def use_config(
 
 # default decorators
 def use_json_config(
-    section: Optional[List[str]] = None,
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
-    default_value: Optional[TyperParameterValue] = None,
+    default_value: TyperParameterValue | None = None,
 ) -> TyperCommandDecorator:
     """Decorator for using JSON configuration on a typer command.
 
@@ -154,10 +154,10 @@ def use_json_config(
 
 
 def use_yaml_config(
-    section: Optional[List[str]] = None,
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
-    default_value: Optional[TyperParameterValue] = None,
+    default_value: TyperParameterValue | None = None,
 ) -> TyperCommandDecorator:
     """Decorator for using YAML configuration on a typer command.
 
@@ -206,10 +206,10 @@ def use_yaml_config(
 
 
 def use_toml_config(
-    section: Optional[List[str]] = None,
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
-    default_value: Optional[TyperParameterValue] = None,
+    default_value: TyperParameterValue | None = None,
 ) -> TyperCommandDecorator:
     """Decorator for using TOML configuration on a typer command.
 
@@ -258,10 +258,10 @@ def use_toml_config(
 
 
 def use_dotenv_config(
-    section: Optional[List[str]] = None,
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
-    default_value: Optional[TyperParameterValue] = None,
+    default_value: TyperParameterValue | None = None,
 ) -> TyperCommandDecorator:
     """Decorator for using dotenv configuration on a typer command.
 
@@ -310,10 +310,10 @@ def use_dotenv_config(
 
 
 def use_ini_config(
-    section: List[str],
+    section: list[str],
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
-    default_value: Optional[TyperParameterValue] = None,
+    default_value: TyperParameterValue | None = None,
 ) -> TyperCommandDecorator:
     """Decorator for using INI configuration on a typer command.
 
@@ -361,8 +361,8 @@ def use_ini_config(
 
 
 def use_multifile_config(
-    default_files: List[TyperParameterValue],
-    section: Optional[List[str]] = None,
+    default_files: list[TyperParameterValue],
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
 ) -> TyperCommandDecorator:
@@ -425,8 +425,8 @@ def use_multifile_config(
 
 
 def use_fallback_config(
-    fallback_files: List[TyperParameterValue],
-    section: Optional[List[str]] = None,
+    fallback_files: list[TyperParameterValue],
+    section: list[str] | None = None,
     param_name: TyperParameterName = "config",
     param_help: str = "Configuration file.",
 ) -> TyperCommandDecorator:

--- a/src/typer_config/dumpers.py
+++ b/src/typer_config/dumpers.py
@@ -1,6 +1,7 @@
 """Config Dictionary Dumpers."""
 
 import json
+from pathlib import Path
 
 from .__optional_imports import try_import
 from .__typing import ConfigDict, FilePath
@@ -13,7 +14,7 @@ def json_dumper(config: ConfigDict, location: FilePath) -> None:
         config (ConfigDict): configuration
         location (FilePath): file to write
     """
-    with open(location, "w", encoding="utf-8") as _file:
+    with Path(location).open("w", encoding="utf-8") as _file:
         json.dump(config, _file)
 
 
@@ -34,7 +35,7 @@ def yaml_dumper(config: ConfigDict, location: FilePath) -> None:
         message = "Please install the pyyaml library."
         raise ModuleNotFoundError(message)
 
-    with open(location, "w", encoding="utf-8") as _file:
+    with Path(location).open("w", encoding="utf-8") as _file:
         yaml.dump(config, _file)
 
 
@@ -55,5 +56,5 @@ def toml_dumper(config: ConfigDict, location: FilePath) -> None:
         message = "Please install the toml library to write TOML files."
         raise ModuleNotFoundError(message)
 
-    with open(location, "w", encoding="utf-8") as _file:
+    with Path(location).open("w", encoding="utf-8") as _file:
         toml.dump(config, _file)

--- a/src/typer_config/loaders.py
+++ b/src/typer_config/loaders.py
@@ -6,9 +6,10 @@ These loaders must implement the `typer_config.__typing.ConfigLoader` interface.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from configparser import ConfigParser
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Optional
+from typing import TYPE_CHECKING, Any
 
 from .__optional_imports import try_import
 
@@ -25,9 +26,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def loader_transformer(
     loader: ConfigLoader,
-    loader_conditional: Optional[ConfigLoaderConditional] = None,
-    param_transformer: Optional[TyperParameterValueTransformer] = None,
-    config_transformer: Optional[ConfigDictTransformer] = None,
+    loader_conditional: ConfigLoaderConditional | None = None,
+    param_transformer: TyperParameterValueTransformer | None = None,
+    config_transformer: ConfigDictTransformer | None = None,
 ) -> ConfigLoader:
     """Configuration loader transformer.
 
@@ -113,7 +114,7 @@ def yaml_loader(param_value: TyperParameterValue) -> ConfigDict:
         message = "Please install the pyyaml library."
         raise ModuleNotFoundError(message)
 
-    with open(param_value, "r", encoding="utf-8") as _file:
+    with Path(param_value).open("r", encoding="utf-8") as _file:
         conf: ConfigDict = yaml.safe_load(_file)
 
     return conf
@@ -129,7 +130,7 @@ def json_loader(param_value: TyperParameterValue) -> ConfigDict:
         ConfigDict: dictionary loaded from file
     """
 
-    with open(param_value, "r", encoding="utf-8") as _file:
+    with Path(param_value).open("r", encoding="utf-8") as _file:
         conf: ConfigDict = json.load(_file)
 
     return conf
@@ -152,7 +153,7 @@ def toml_loader(param_value: TyperParameterValue) -> ConfigDict:
     tomllib = try_import("tomllib")
 
     if tomllib is not None:
-        with open(param_value, "rb") as _file:
+        with Path(param_value).open("rb") as _file:
             return tomllib.load(_file)
 
     # couldn't find `tommllib`, so try `toml`
@@ -162,7 +163,7 @@ def toml_loader(param_value: TyperParameterValue) -> ConfigDict:
         message = "Please install the toml library."
         raise ModuleNotFoundError(message)
 
-    with open(param_value, "r", encoding="utf-8") as _file:
+    with Path(param_value).open("r", encoding="utf-8") as _file:
         return toml.load(_file)
 
 
@@ -185,7 +186,7 @@ def dotenv_loader(param_value: TyperParameterValue) -> ConfigDict:
         message = "Please install the python-dotenv library."
         raise ModuleNotFoundError(message)
 
-    with open(param_value, "r", encoding="utf-8") as _file:
+    with Path(param_value).open("r", encoding="utf-8") as _file:
         # NOTE: I'm using a stream here so that the loader
         # will raise an exception when the file doesn't exist.
         conf: ConfigDict = dotenv.dotenv_values(stream=_file)
@@ -216,7 +217,7 @@ def ini_loader(param_value: TyperParameterValue) -> ConfigDict:
     """
 
     ini_parser = ConfigParser()
-    with open(param_value, "r", encoding="utf-8") as _file:
+    with Path(param_value).open("r", encoding="utf-8") as _file:
         ini_parser.read_file(_file)
 
     conf: ConfigDict = {

--- a/src/typer_config/utils.py
+++ b/src/typer_config/utils.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from warnings import showwarning
 
 ORIGINAL_WARNING_FORMATTER = warnings.formatwarning
 
 
 def get_dict_section(
-    _dict: Dict[Any, Any], keys: Optional[List[Any]] = None
-) -> Dict[Any, Any]:
+    _dict: dict[Any, Any], keys: list[Any] | None = None
+) -> dict[Any, Any]:
     """Get section of a dictionary.
 
     Args:
@@ -53,7 +53,7 @@ class SimpleWarningFormat:
         warnings.formatwarning = ORIGINAL_WARNING_FORMATTER
 
 
-def file_exists_and_warn(file_path: Union[Path, str]) -> bool:
+def file_exists_and_warn(file_path: Path | str) -> bool:
     """Check if file exists and warn if it doesn't exist.
 
     Args:

--- a/tests/doc_examples.py
+++ b/tests/doc_examples.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from subprocess import run
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, NamedTuple
 
 CLASS_RE = re.compile(
     dedent(r"""
@@ -102,13 +102,13 @@ class Fence(NamedTuple):
     """Markdown Fence."""
 
     fence: str = ""
-    lang: Optional[str] = None
-    attrs: "Optional[OrderedDict[str, Attr]]" = None
-    options: Optional[Dict[str, Any]] = None
+    lang: str | None = None
+    attrs: "OrderedDict[str, Attr] | None" = None
+    options: dict[str, Any] | None = None
     contents: str = ""
-    raw: Optional[str] = None
+    raw: str | None = None
 
-    def options_from_str(raw: str) -> Dict[str, Any]:
+    def options_from_str(raw: str) -> dict[str, Any]:
         """Markdown fence options dict from string.
 
         Args:
@@ -152,7 +152,7 @@ class Fence(NamedTuple):
             raw = raw[match.span()[1] :]
         return attrs
 
-    def from_re_groups(groups: Tuple[str]) -> "Fence":
+    def from_re_groups(groups: tuple[str]) -> "Fence":
         """Make Fence from regex groups.
 
         Notes:
@@ -252,7 +252,7 @@ def register_executor(lang, executor):
     _executors[lang] = executor
 
 
-def grab_fences(source: str) -> List[Fence]:
+def grab_fences(source: str) -> list[Fence]:
     """Grab fences in  markdown.
 
     Args:
@@ -272,7 +272,7 @@ def exec_file_fence(fence: Fence, **kwargs):
         **kwargs: not used
     """
     fname = fence.options.get("title", None) or fence.attrs.get("title", [None])[0]
-    with open(fname, "w") as f:
+    with Path(fname).open("w") as f:
         f.write(fence.contents)
 
 
@@ -283,7 +283,7 @@ register_executor("dotenv", exec_file_fence)
 register_executor("ini", exec_file_fence)
 
 
-def exec_python_fence(fence: Fence, globals_: Optional[Dict] = None):
+def exec_python_fence(fence: Fence, globals_: dict | None = None):
     """Python fence executor.
 
     Args:
@@ -313,7 +313,7 @@ def exec_bash_fence(fence: Fence, **kwargs):
         **kwargs: not used
     """
     _cmds = fence.contents.split("$ ")
-    commands: List[Dict] = []
+    commands: list[dict] = []
     for _cmd in _cmds:
         if not _cmd:
             continue
@@ -339,7 +339,7 @@ def check_typer_md_file(fpath: Path):
     Args:
         fpath (Path): path to markdown file
     """
-    with open(fpath, "r") as f:
+    with Path(fpath).open("r") as f:
         source = f.read()
     fences = grab_fences(source)
 


### PR DESCRIPTION
## Summary

**Repo health:** 27/100

Our analysis found **~61 format/lint tidy opportunities** and about **23 refactoring opportunities** across the reviewed scope. Security scans were clean; code duplication is moderate (~14% in Python modules per jscpd); maintainability index and cyclomatic complexity look good in core loader/decorator modules; about 23 structural refactor suggestions remain (mostly test helper patterns).

This pull request is a **sample** of those findings — **8 files, ~105 focused line changes** — not a full format pass or refactor cleanup.

## What you are doing right

- No secrets detected in scope (gitleaks).
- Maintainability index and cyclomatic complexity look good for core config loader modules (radon).
- Strong CI matrix (Python 3.10–3.14 across Linux/macOS/Windows) with type checking via `ty`.
- Clean decorator/loader architecture with thoughtful optional-dependency handling.
- Modern `pyproject.toml` (PEP 621) with uv-based dev workflow.

## What you could improve

- **Duplicate code:** jscpd reported ~14% duplicated lines in Python modules — mostly repeated loader/dumper patterns across `loaders.py` and `dumpers.py`. *(follow-up)*
- **Refactoring:** About 23 `refactor check --strict` suggestions remain — e.g. simplify nested control flow in `get_dict_section` in `utils.py` and consolidate repeated decorator boilerplate in `decorators.py`. *(follow-up)*
- **Dependencies:** `deptry` flagged `python-dotenv`, `toml`, and `pyyaml` as declared but not directly imported (they are loaded via `try_import`) — likely false positives for optional extras. *(defer)*
- **Lint / style:** Modernize legacy `typing.List` / `Optional` annotations to built-in `list` and `X | None`. *(included in example PR)*
- **Lint / style:** Use `Path.open()` instead of builtin `open()` in loaders, dumpers, and doc-example tests for pathlib consistency. *(included in example PR)*
- **Lint / style:** Remove unnecessary parentheses from `@lru_cache()`. *(included in example PR)*

## Changes

- `src/typer_config/__optional_imports.py` — use `@lru_cache` without redundant parentheses.
- `src/typer_config/__typing.py` — modernize `Callable` import and `dict` / union type annotations.
- `src/typer_config/callbacks.py` — replace `List` / `Optional` with `list` / `| None`.
- `src/typer_config/decorators.py` — modernize list/optional type hints across decorator factories.
- `src/typer_config/dumpers.py` — use `Path.open()` for JSON/YAML/TOML config writes.
- `src/typer_config/loaders.py` — use `Path.open()` for all config file reads.
- `src/typer_config/utils.py` — modernize type hints in `get_dict_section` and warning formatter.
- `tests/doc_examples.py` — modernize type hints and use `Path.open()` in doc fence helpers.

---
*Review summary produced with [ShipGate](https://github.com/inquilabee/shipgate) — a policy-first quality orchestrator that runs linters, formatters, security scanners, and refactor checks from one catalog. This PR used `check` + `refactor check --strict` to find issues; [docs](https://inquilabee.github.io/shipgate/).*
